### PR TITLE
Update image and action version

### DIFF
--- a/.github/workflows/buildTag.yml
+++ b/.github/workflows/buildTag.yml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Get Latest Tag
         id: get_tag
-        uses: WyriHaximus/github-action-get-previous-tag@v1.1
+        uses: WyriHaximus/github-action-get-previous-tag@v1
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -29,4 +29,3 @@ jobs:
 
       - name: Build and push
         run: docker build -t ghcr.io/${{ github.repository_owner }}/hsr:${{ steps.get_tag.outputs.tag }} . && docker push ghcr.io/${{ github.repository_owner }}/hsr:${{ steps.get_tag.outputs.tag }}
-

--- a/action.yaml
+++ b/action.yaml
@@ -65,8 +65,7 @@ runs:
   using: 'docker'
   # uncomment for dev purposes
   # image: 'Dockerfile'
-  # image: 'docker://kio.ee/kyberorg/hsr:v0.5.2'
-  image: 'docker://ghcr.io/yashid-mohamed/hsr:dev'
+  image: 'docker://ghcr.io/yashid-mohamed/hsr:v0.5.3'
   args:
     - ${{ inputs.harbor-host }}
     - ${{ inputs.harbor-robot }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow and the `action.yaml` file to use newer versions of dependencies and container images. The most important changes include updating the GitHub Action for fetching the previous tag, removing an unnecessary empty line in the workflow, and updating the container image version in `action.yaml`.

### Workflow updates:
* [`.github/workflows/buildTag.yml`](diffhunk://#diff-0da636acdb5f8519784846f98bab6e3b967a85816076ff68a9e18c78ab7a6196L18-R18): Updated the GitHub Action `WyriHaximus/github-action-get-previous-tag` from version `v1.1` to `v1`. This ensures compatibility with the latest version of the action.
* [`.github/workflows/buildTag.yml`](diffhunk://#diff-0da636acdb5f8519784846f98bab6e3b967a85816076ff68a9e18c78ab7a6196L32): Removed an unnecessary empty line after the `docker build` and `docker push` command for better readability.

### Container image update:
* [`action.yaml`](diffhunk://#diff-fab4d7fb461bc6fbe9587f6c03fff98102b1c744145edcf2a993f2ff7cb05a0dL68-R68): Updated the container image from `ghcr.io/yashid-mohamed/hsr:dev` to `ghcr.io/yashid-mohamed/hsr:v0.5.3` to use the latest stable version.